### PR TITLE
Search for account in LDAP with matching username, then perform LDAP bind with that user

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ LDAP configuration:
   LDAP_PORT = 389
 
   # Full DN of the service account use to connect to LDAP server and search for login user's account entry
+  # If LDAP_BIND_DN is not specified, or is blank, then an anonymous bind is attempated
   LDAP_BIND_DN = 'CN=SVC Account,OU=Service Accounts,OU=Servers,DC=example,DC=com'
-  LDAP_BIND_PASSWORD = 'replace_me'   # eg. 
+  LDAP_BIND_PASSWORD = 'replace_me'   # eg.
   # Starting point within LDAP structure to search for login user
   LDAP_SEARCH_BASE = 'OU=DevTeam,DC=example,DC=net'
   # LDAP property used for searching, ie. login username needs to match value in sAMAccountName property in LDAP
@@ -40,14 +41,14 @@ LDAP configuration:
 ```
 
 The logic of the code is such that a dedicated domain service account user performs a search on LDAP for an account that has a LDAP_SEARCH_PROPERTY value that matches the username the user typed in on the Taiga login form.  
-If the search is successful, then the code uses this value and the typed-in password to attempt a bind to LDAP using these credentials.   
+If the search is successful, then the code uses this value and the typed-in password to attempt a bind to LDAP using these credentials.
 If the bind is successful, then we can say that the user is authorised to log in to Taiga.
-   
-   
 
-RECOMMENDATION: Note that a service account needs to be available for performing the LDAP search for the user that is logging on to Taiga.   
-For security reasons, the service account user should be configured to only allow reading/searching the LDAP structure. No other LDAP (or wider network) permissions should be granted for this user because you need to specify the service account password in this file.   
-A suitably strong password should be chosen, eg. VmLYBbvJaf2kAqcrt5HjHdG6   
+If the LDAP_BIND_DN configuration setting is not specified or is blank, then an anonymous bind is attempted to search for the login user's LDAP account entry.
+
+
+RECOMMENDATION: Note that if you are using a service account for performing the LDAP search for the user that is logging on to Taiga, for security reasons, the service account user should be configured to only allow reading/searching the LDAP structure. No other LDAP (or wider network) permissions should be granted for this user because you need to specify the service account password in this file.
+A suitably strong password should be chosen, eg. VmLYBbvJaf2kAqcrt5HjHdG6
 
 
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,34 @@ LDAP configuration:
 
 ```python
   INSTALLED_APPS += ["taiga_contrib_ldap_auth"]
-  LDAP_SERVER = "ldap://ldap.example.com"
-  LDAP_DN_FORMAT = "uid={username},cn=users,dc=example,dc=com"
-  LDAP_BASE_EMAIL = "@example.com"
+
+  LDAP_SERVER = 'ldap://ldap.example.com'
+  LDAP_PORT = 389
+
+  # Full DN of the service account use to connect to LDAP server and search for login user's account entry
+  LDAP_BIND_DN = 'CN=SVC Account,OU=Service Accounts,OU=Servers,DC=example,DC=com'
+  LDAP_BIND_PASSWORD = 'replace_me'   # eg. 
+  # Starting point within LDAP structure to search for login user
+  LDAP_SEARCH_BASE = 'OU=DevTeam,DC=example,DC=net'
+  # LDAP property used for searching, ie. login username needs to match value in sAMAccountName property in LDAP
+  LDAP_SEARCH_PROPERTY = 'sAMAccountName'
+
+  # Names of LDAP properties on user account to get email and full name
+  LDAP_EMAIL_PROPERTY = 'mail'
+  LDAP_FULL_NAME_PROPERTY = 'name'
 ```
+
+The logic of the code is such that a dedicated domain service account user performs a search on LDAP for an account that has a LDAP_SEARCH_PROPERTY value that matches the username the user typed in on the Taiga login form.  
+If the search is successful, then the code uses this value and the typed-in password to attempt a bind to LDAP using these credentials.   
+If the bind is successful, then we can say that the user is authorised to log in to Taiga.
+   
+   
+
+RECOMMENDATION: Note that a service account needs to be available for performing the LDAP search for the user that is logging on to Taiga.   
+For security reasons, the service account user should be configured to only allow reading/searching the LDAP structure. No other LDAP (or wider network) permissions should be granted for this user because you need to specify the service account password in this file.   
+A suitably strong password should be chosen, eg. VmLYBbvJaf2kAqcrt5HjHdG6   
+
+
 
 ### Taiga Front
 

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -66,7 +66,6 @@ def login(username: str, password: str) -> tuple:
 
             user_conn = Connection(server, auto_bind = True, client_strategy = SYNC, user = dn, password = password, authentication = SIMPLE, check_names = True)
 
-            # TODO: fetch email and fullname information from LDAP server
             return (user_email, full_name)
 
         raise LDAPLoginError({"error_message": "Username or password incorrect"})

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from ldap3 import Server, Connection, AUTH_SIMPLE, STRATEGY_SYNC, SIMPLE, SYNC, ASYNC, SUBTREE, ALL
+from ldap3 import Server, Connection, AUTH_SIMPLE, AUTH_ANONYMOUS, STRATEGY_SYNC, SIMPLE, SYNC, ASYNC, SUBTREE, ALL
 
 from django.conf import settings
 from taiga.base.connectors.exceptions import ConnectorBaseException
@@ -41,7 +41,12 @@ def login(username: str, password: str) -> tuple:
 
     try:
         server = Server(SERVER, port = PORT, get_info = ALL)  # define an unsecure LDAP server, requesting info on DSE and schema
-        c = Connection(server, auto_bind = True, client_strategy = SYNC, user=BIND_DN, password=BIND_PASSWORD, authentication=SIMPLE, check_names=True)
+        c = None
+
+        if BIND_DN is not None and BIND_DN != '':
+            c = Connection(server, auto_bind = True, client_strategy = SYNC, user=BIND_DN, password=BIND_PASSWORD, authentication=AUTH_SIMPLE, check_names=True)
+        else:
+            c = Connection(server, auto_bind = True, client_strategy = SYNC, user=None, password=None, authentication=AUTH_ANONYMOUS, check_names=True)
 
     except Exception as e:
         error = "Error connecting to LDAP server: %s" % e


### PR DESCRIPTION
I have documented the authentication logic for this version in the README, underneath the config settings.

Couple of points:

a) Unit tests aren't my strong point! The existing unit tests don't work and I'm struggling to see how to write/update them so that they'd be useful, given you need to connect to an LDAP server to check if the code is working as it should.   Please feel free to suggest ideas and I'll be happy to update the tests.

b) Now that the login is doing two things (first searching for a matching user and then attempting a successful bind), it can take a number of seconds.  The login button on Taiga login page form doesn't seem to change state, eg. show a progress indicator, so the user doesn't have any feedback as to what is happening while the login process is taking place.  
I've hacked a solution in my instance that disables the username and password box and login button, and changes the text to "Signing In..." but it certainly isn't a good enough solution to raise a PR on taiga-front!
