### PR TITLE
Allow email addresses as LDAP search properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ LDAP configuration:
   LDAP_SEARCH_BASE = 'OU=DevTeam,DC=example,DC=net'
   # LDAP property used for searching, ie. login username needs to match value in sAMAccountName property in LDAP
   LDAP_SEARCH_PROPERTY = 'sAMAccountName'
+  LDAP_SEARCH_SUFFIX = None # '@example.com'
 
   # Names of LDAP properties on user account to get email and full name
   LDAP_EMAIL_PROPERTY = 'mail'
@@ -41,6 +42,8 @@ LDAP configuration:
 The logic of the code is such that a dedicated domain service account user performs a search on LDAP for an account that has a LDAP_SEARCH_PROPERTY value that matches the username the user typed in on the Taiga login form.  
 If the search is successful, then the code uses this value and the typed-in password to attempt a bind to LDAP using these credentials.
 If the bind is successful, then we can say that the user is authorised to log in to Taiga.
+
+Optionally LDAP_SEARCH_SUFFIX can be set to allow for the search to match only the beginning of a field containing e.g. an email address.
 
 If the LDAP_BIND_DN configuration setting is not specified or is blank, then an anonymous bind is attempted to search for the login user's LDAP account entry.
 

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -30,6 +30,7 @@ PORT = getattr(settings, "LDAP_PORT", "")
 
 SEARCH_BASE = getattr(settings, "LDAP_SEARCH_BASE", "")
 SEARCH_PROPERTY = getattr(settings, "LDAP_SEARCH_PROPERTY", "")
+SEARCH_SUFFIX = getattr(settings, "LDAP_SEARCH_SUFFIX", "")
 BIND_DN = getattr(settings, "LDAP_BIND_DN", "")
 BIND_PASSWORD = getattr(settings, "LDAP_BIND_PASSWORD", "")
 
@@ -37,7 +38,6 @@ EMAIL_PROPERTY = getattr(settings, "LDAP_EMAIL_PROPERTY", "")
 FULL_NAME_PROPERTY = getattr(settings, "LDAP_FULL_NAME_PROPERTY", "")
 
 def login(username: str, password: str) -> tuple:
-
 
     try:
         server = Server(SERVER, port = PORT, get_info = ALL)  # define an unsecure LDAP server, requesting info on DSE and schema
@@ -53,8 +53,12 @@ def login(username: str, password: str) -> tuple:
         raise LDAPLoginError({"error_message": error})
 
     try:
+        if(SEARCH_SUFFIX is not None and SEARCH_SUFFIX != ''):
+            search_filter = '(%s=%s)' % (SEARCH_PROPERTY, username + SEARCH_SUFFIX)
+        else:
+            search_filter = '(%s=%s)' % (SEARCH_PROPERTY, username)
         c.search(search_base = SEARCH_BASE,
-                 search_filter = '(%s=%s)' % (SEARCH_PROPERTY, username),
+                 search_filter = search_filter,
                  search_scope = SUBTREE,
                  attributes = [EMAIL_PROPERTY,FULL_NAME_PROPERTY],
                  paged_size = 5)


### PR DESCRIPTION
Allow cases where LDAP servers are configured to merely present email
addresses, rather than pure usernames. When setting LDAP_SEARCH_SUFFIX,
it is added to the username when trying to match with SEARCH_PROPERTY.
