### PR TITLE
Provide SSL support for LDAP authentication

### DIFF
--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -40,7 +40,11 @@ FULL_NAME_PROPERTY = getattr(settings, "LDAP_FULL_NAME_PROPERTY", "")
 def login(username: str, password: str) -> tuple:
 
     try:
-        server = Server(SERVER, port = PORT, get_info = NONE)  # define an unsecure LDAP server, requesting info on DSE and schema
+        if SERVER.startswith("ldaps://"):
+            server = Server(SERVER, port = PORT, get_info = NONE, use_ssl = True) 
+        else:
+            server = Server(SERVER, port = PORT, get_info = NONE, use_ssl = False)  # define an unsecure LDAP server, requesting info on DSE and schema
+
         c = None
 
         if BIND_DN is not None and BIND_DN != '':

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -40,7 +40,7 @@ FULL_NAME_PROPERTY = getattr(settings, "LDAP_FULL_NAME_PROPERTY", "")
 def login(username: str, password: str) -> tuple:
 
     try:
-        if SERVER.startswith("ldaps://"):
+        if SERVER.lower().startswith("ldaps://"):
             server = Server(SERVER, port = PORT, get_info = NONE, use_ssl = True) 
         else:
             server = Server(SERVER, port = PORT, get_info = NONE, use_ssl = False)  # define an unsecure LDAP server, requesting info on DSE and schema


### PR DESCRIPTION
If SERVER config setting starts with ldaps://, then SSL is used to connect to the LDAP server.
