### PR TITLE
Add ability to extend search filter.

### DIFF
--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -31,6 +31,7 @@ PORT = getattr(settings, "LDAP_PORT", "")
 SEARCH_BASE = getattr(settings, "LDAP_SEARCH_BASE", "")
 SEARCH_PROPERTY = getattr(settings, "LDAP_SEARCH_PROPERTY", "")
 SEARCH_SUFFIX = getattr(settings, "LDAP_SEARCH_SUFFIX", "")
+SEARCH_FILTER = getattr(settings, "LDAP_SEARCH_FILTER", "")
 BIND_DN = getattr(settings, "LDAP_BIND_DN", "")
 BIND_PASSWORD = getattr(settings, "LDAP_BIND_PASSWORD", "")
 
@@ -61,6 +62,8 @@ def login(username: str, password: str) -> tuple:
             search_filter = '(%s=%s)' % (SEARCH_PROPERTY, username + SEARCH_SUFFIX)
         else:
             search_filter = '(%s=%s)' % (SEARCH_PROPERTY, username)
+        if SEARCH_FILTER:
+            search_filter = '(&%s(%s))' % (search_filter, SEARCH_FILTER)
         c.search(search_base = SEARCH_BASE,
                  search_filter = search_filter,
                  search_scope = SUBTREE,


### PR DESCRIPTION
This patch adds a config option: `LDAP_SEARCH_FILTER` which allows the config to specify additional filter parameters on the ldap search.

For example, setting:

`LDAP_SEARCH_FILTER = 'memberOf=admins,ou=groups,dc=example,dc=com'`

Would limit logins tp members of the `admins` group

The patch is generic enough that in theory you could use more extensive LDAP filter patterns - though I haven't tested this, e.g.:

`LDAP_SEARCH_FILTER = '|(memberOf=admins,ou=groups,dc=example,dc=com)(memberOf=helpdesk,ou=groups,dc=example,dc=com)'`

Would allow logins for member so either `admins` or `helpdesk` groups.
