### PR TITLE
Delay the import of register_auth_plugin due to Taiga 2.0 Django 1.9 upgrade

### DIFF
--- a/taiga_contrib_ldap_auth/apps.py
+++ b/taiga_contrib_ldap_auth/apps.py
@@ -17,13 +17,12 @@
 from django.apps import AppConfig
 from django.db.models import signals
 
-from taiga.auth.services import register_auth_plugin
-from . import services
-
 
 class TaigaContribLDAPAuthAppConfig(AppConfig):
     name = "taiga_contrib_ldap_auth"
     verbose_name = "Taiga contrib ldap auth App Config"
 
     def ready(self):
+        from taiga.auth.services import register_auth_plugin
+        from . import services
         register_auth_plugin("ldap", services.ldap_login_func)


### PR DESCRIPTION
With Taiga 2.0 the change to Django 1.9 seems to change the order in which apps are loaded, or some other reason, but delaying the import fixes the issue.

discussed in #29 
