### PR TITLE
services: update user's DB entry from LDAP (if needed)

### DIFF
--- a/taiga_contrib_ldap_auth/services.py
+++ b/taiga_contrib_ldap_auth/services.py
@@ -47,6 +47,11 @@ def ldap_register(username: str, email: str, full_name: str):
                                          full_name=full_name)
         user_registered_signal.send(sender=user.__class__, user=user)
 
+    # update DB entry if LDAP field values differ
+    if user.email != email or user.full_name != full_name:
+        user_model.objects.filter(pk = user.pk).update(email = email, full_name = full_name)
+        user.refresh_from_db()
+
     return user
 
 


### PR DESCRIPTION
Updates the Taiga / Django database entry if LDAP returned different e-mail or full name values.

Before this, for example, if the e-mail value changed in LDAP, logging into Taiga would still only be possible with the old e-mail. If editing e-mail is disabled (e.g. as described [here](https://github.com/ensky/taiga-contrib-ldap-auth/issues/21#issuecomment-147531439)), this means the user has to remember their first-ever login e-mail. And if editing is enabled, then the user would still have to update this manually.

(Username is assumed non-changing here. Not sure what happens to Taiga/Django if the `username` changes - are all references changed or orphaned?..)

Note: this is **not** the PR mentioned in issue 37.