### PR TITLE
Search for LDAP entry by both username and e-mail + large refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,70 +17,60 @@ If needed, change `pip` to `pip3` to use the Python 3 version.
 
 ## Configuration
 
-### Taiga Back
+### taiga-back
 
 Add the following to `settings/local.py`:
 
 ```python
-  INSTALLED_APPS += ["taiga_contrib_ldap_auth"]
+INSTALLED_APPS += ["taiga_contrib_ldap_auth"]
 
-  LDAP_SERVER = 'ldap://ldap.example.com'
-  LDAP_PORT = 389
+LDAP_SERVER = 'ldap://ldap.example.com'
+LDAP_PORT = 389
 
-  # Full DN of the service account use to connect to LDAP server and search for login user's account entry
-  # If LDAP_BIND_DN is not specified, or is blank, then an anonymous bind is attempated
-  LDAP_BIND_DN = 'CN=SVC Account,OU=Service Accounts,OU=Servers,DC=example,DC=com'
-  LDAP_BIND_PASSWORD = 'replace_me'   # eg.
+# Full DN of the service account use to connect to LDAP server and search for login user's account entry
+# If LDAP_BIND_DN is not specified, or is blank, then an anonymous bind is attempated
+LDAP_BIND_DN = 'CN=SVC Account,OU=Service Accounts,OU=Servers,DC=example,DC=com'
+LDAP_BIND_PASSWORD = '<REPLACE_ME>'
 
-  # Starting point within LDAP structure to search for login user
-  LDAP_SEARCH_BASE = 'OU=DevTeam,DC=example,DC=net'
+# Starting point within LDAP structure to search for login user
+LDAP_SEARCH_BASE = 'OU=DevTeam,DC=example,DC=net'
 
-  # LDAP attribute used for searching (user-provided login value will have to match this attribute's value)
-  LDAP_SEARCH_ATTRIBUTE = 'uid'
-  # Append this to user-provided login value given above before performing search operation
-  LDAP_SEARCH_ATTRIBUTE_SUFFIX = None # '@example.com'
-  # Additional search criteria to the filter (will be ANDed)
-  #LDAP_SEARCH_FILTER = 'mail=*'
+# Additional search criteria to the filter (will be ANDed)
+#LDAP_SEARCH_FILTER_ADDITIONAL = '(mail=*)'
 
-  # Names of attributes to get email and full name values from
-  LDAP_EMAIL_ATTRIBUTE = 'mail'
-  LDAP_FULL_NAME_ATTRIBUTE = 'displayName'
+# Names of attributes to get username, e-mail and full name values from
+LDAP_USERNAME_ATTRIBUTE = 'uid'
+LDAP_EMAIL_ATTRIBUTE = 'mail'
+LDAP_FULL_NAME_ATTRIBUTE = 'displayName'
 ```
 
 A dedicated domain service account user (specified by `LDAP_BIND_DN`)
-performs a search on LDAP for
-an account that has a `LDAP_SEARCH_ATTRIBUTE` matching the
-user-provided login.
+performs a search on LDAP for an account that has a
+`LDAP_SEARCH_ATTRIBUTE` matching the user-provided login.
 
-If the search is
-successful, then the returned entry and the user-provided password
-to attempt a bind to LDAP. If the bind is
+If the search is successful, then the returned entry and the
+user-provided password  are used to attempt a bind to LDAP. If the bind is
 successful, then we can say that the user is authorised to log in to
 Taiga.
-
-Optionally `LDAP_SEARCH_ATTRIBUTE_SUFFIX` can be set to append a string
-to the login field.
 
 If the `LDAP_BIND_DN` configuration setting is not specified or is
 blank, then an anonymous bind is attempted to search for the login
 user's LDAP account entry.
 
-
-RECOMMENDATION: Note that if you are using a service account for
-performing the LDAP search for the user that is logging on to Taiga,
-for security reasons, the service account user should be configured to
-only allow reading/searching the LDAP structure. No other LDAP (or wider
+**RECOMMENDATION**: for security reasons, if you are using a service
+account for performing the LDAP search, it should be configured to only
+allow reading/searching the LDAP structure. No other LDAP (or wider
 network) permissions should be granted for this user because you need
-to specify the service account password in this file. A suitably strong
-password should be chosen, eg. VmLYBbvJaf2kAqcrt5HjHdG6
+to specify the service account password in the configuration file. A
+suitably strong password should be chosen, eg. VmLYBbvJaf2kAqcrt5HjHdG6
 
 
-### Taiga Front
+### taiga-front
 
 Change the `loginFormType` setting to `"ldap"` in `dist/js/conf.json`:
 
 ```json
-...
+    ...
     "loginFormType": "ldap",
-...
+    ...
 ```

--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
-Taiga contrib ldap auth
-=======================
+# Taiga contrib ldap auth
 
-The Taiga plugin for ldap authentication.
+Taiga.io plugin for LDAP authentication.
 
-Installation
-------------
 
-### Taiga Back
+## Installation
 
-In your Taiga back python virtualenv install the pip package
-`taiga-contrib-ldap-auth` with:
+Install the PIP package `taiga-contrib-ldap-auth` in your
+`taiga-back` python virtualenv:
 
 ```bash
   pip install taiga-contrib-ldap-auth
 ```
 
-Modify your settings/local.py and include it on `INSTALLED_APPS` and add your
-LDAP configuration:
+If needed, change `pip` to `pip3` to use the Python 3 version.
+
+
+## Configuration
+
+### Taiga Back
+
+Add the following to `settings/local.py`:
 
 ```python
   INSTALLED_APPS += ["taiga_contrib_ldap_auth"]
@@ -28,34 +31,53 @@ LDAP configuration:
   # If LDAP_BIND_DN is not specified, or is blank, then an anonymous bind is attempated
   LDAP_BIND_DN = 'CN=SVC Account,OU=Service Accounts,OU=Servers,DC=example,DC=com'
   LDAP_BIND_PASSWORD = 'replace_me'   # eg.
+
   # Starting point within LDAP structure to search for login user
   LDAP_SEARCH_BASE = 'OU=DevTeam,DC=example,DC=net'
-  # LDAP property used for searching, ie. login username needs to match value in sAMAccountName property in LDAP
-  LDAP_SEARCH_PROPERTY = 'sAMAccountName'
-  LDAP_SEARCH_SUFFIX = None # '@example.com'
 
-  # Names of LDAP properties on user account to get email and full name
-  LDAP_EMAIL_PROPERTY = 'mail'
-  LDAP_FULL_NAME_PROPERTY = 'name'
+  # LDAP attribute used for searching (user-provided login value will have to match this attribute's value)
+  LDAP_SEARCH_ATTRIBUTE = 'uid'
+  # Append this to user-provided login value given above before performing search operation
+  LDAP_SEARCH_ATTRIBUTE_SUFFIX = None # '@example.com'
+  # Additional search criteria to the filter (will be ANDed)
+  #LDAP_SEARCH_FILTER = 'mail=*'
+
+  # Names of attributes to get email and full name values from
+  LDAP_EMAIL_ATTRIBUTE = 'mail'
+  LDAP_FULL_NAME_ATTRIBUTE = 'displayName'
 ```
 
-The logic of the code is such that a dedicated domain service account user performs a search on LDAP for an account that has a LDAP_SEARCH_PROPERTY value that matches the username the user typed in on the Taiga login form.  
-If the search is successful, then the code uses this value and the typed-in password to attempt a bind to LDAP using these credentials.
-If the bind is successful, then we can say that the user is authorised to log in to Taiga.
+A dedicated domain service account user (specified by `LDAP_BIND_DN`)
+performs a search on LDAP for
+an account that has a `LDAP_SEARCH_ATTRIBUTE` matching the
+user-provided login.
 
-Optionally LDAP_SEARCH_SUFFIX can be set to allow for the search to match only the beginning of a field containing e.g. an email address.
+If the search is
+successful, then the returned entry and the user-provided password
+to attempt a bind to LDAP. If the bind is
+successful, then we can say that the user is authorised to log in to
+Taiga.
 
-If the LDAP_BIND_DN configuration setting is not specified or is blank, then an anonymous bind is attempted to search for the login user's LDAP account entry.
+Optionally `LDAP_SEARCH_ATTRIBUTE_SUFFIX` can be set to append a string
+to the login field.
+
+If the `LDAP_BIND_DN` configuration setting is not specified or is
+blank, then an anonymous bind is attempted to search for the login
+user's LDAP account entry.
 
 
-RECOMMENDATION: Note that if you are using a service account for performing the LDAP search for the user that is logging on to Taiga, for security reasons, the service account user should be configured to only allow reading/searching the LDAP structure. No other LDAP (or wider network) permissions should be granted for this user because you need to specify the service account password in this file.
-A suitably strong password should be chosen, eg. VmLYBbvJaf2kAqcrt5HjHdG6
-
+RECOMMENDATION: Note that if you are using a service account for
+performing the LDAP search for the user that is logging on to Taiga,
+for security reasons, the service account user should be configured to
+only allow reading/searching the LDAP structure. No other LDAP (or wider
+network) permissions should be granted for this user because you need
+to specify the service account password in this file. A suitably strong
+password should be chosen, eg. VmLYBbvJaf2kAqcrt5HjHdG6
 
 
 ### Taiga Front
 
-Change in your dist/js/conf.json the loginFormType setting to "ldap":
+Change the `loginFormType` setting to `"ldap"` in `dist/js/conf.json`:
 
 ```json
 ...

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ LDAP_FULL_NAME_ATTRIBUTE = 'displayName'
 
 A dedicated domain service account user (specified by `LDAP_BIND_DN`)
 performs a search on LDAP for an account that has a
-`LDAP_SEARCH_ATTRIBUTE` matching the user-provided login.
+`LDAP_USERNAME_ATTRIBUTE` or `LDAP_EMAIL_ATTRIBUTE` matching the
+user-provided login.
 
 If the search is successful, then the returned entry and the
 user-provided password  are used to attempt a bind to LDAP. If the bind is

--- a/taiga_contrib_ldap_auth/__init__.py
+++ b/taiga_contrib_ldap_auth/__init__.py
@@ -14,6 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = (0, 1, 1)
+__version__ = (0, 2, 0)
 
 default_app_config = "taiga_contrib_ldap_auth.apps.TaigaContribLDAPAuthAppConfig"

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -61,16 +61,16 @@ def login(login: str, password: str) -> tuple:
 
     # authenticate as service if credentials provided, anonymously otherwise
     if BIND_DN is not None and BIND_DN != '':
-        user = BIND_DN
-        password = BIND_PASSWORD
-        authentication = SIMPLE
+        service_user = BIND_DN
+        service_pass = BIND_PASSWORD
+        service_auth = SIMPLE
     else:
-        user = None
-        password = None
-        authentication = ANONYMOUS
+        service_user = None
+        service_pass = None
+        service_auth = ANONYMOUS
     try:
         c = Connection(server, auto_bind = True, client_strategy = SYNC, check_names = True,
-                       user = user, password = password, authentication = authentication)
+                       user = service_user, password = service_pass, authentication = service_auth)
     except Exception as e:
         error = "Error connecting to LDAP server: %s" % e
         raise LDAPLoginError({"error_message": error})

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -39,6 +39,15 @@ EMAIL_PROPERTY = getattr(settings, "LDAP_EMAIL_PROPERTY", "")
 FULL_NAME_PROPERTY = getattr(settings, "LDAP_FULL_NAME_PROPERTY", "")
 
 def login(username: str, password: str) -> tuple:
+    """
+    Connect to LDAP server, perform a search and attempt a bind.
+
+    Can raise `exc.LDAPLoginError` exceptions if any of the
+    operations failed.
+
+    :returns: tuple (user_email, full_name)
+
+    """
 
     try:
         if SERVER.lower().startswith("ldaps://"):

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -42,16 +42,21 @@ def login(username: str, password: str) -> tuple:
 
     try:
         if SERVER.lower().startswith("ldaps://"):
-            server = Server(SERVER, port = PORT, get_info = NONE, use_ssl = True) 
+            use_ssl = True
         else:
-            server = Server(SERVER, port = PORT, get_info = NONE, use_ssl = False)  # define an unsecure LDAP server, requesting info on DSE and schema
-
-        c = None
+            use_ssl = False
+        server = Server(SERVER, port = PORT, get_info = NONE, use_ssl = use_ssl)
 
         if BIND_DN is not None and BIND_DN != '':
-            c = Connection(server, auto_bind = True, client_strategy = SYNC, user=BIND_DN, password=BIND_PASSWORD, authentication=SIMPLE, check_names=True)
+            user=BIND_DN
+            password=BIND_PASSWORD
+            authentication=SIMPLE
         else:
-            c = Connection(server, auto_bind = True, client_strategy = SYNC, user=None, password=None, authentication=ANONYMOUS, check_names=True)
+            user=None
+            password=None
+            authentication=ANONYMOUS
+        c = Connection(server, auto_bind = True, client_strategy = SYNC, check_names = True,
+                       user = user, password = password, authentication = authentication)
 
     except Exception as e:
         error = "Error connecting to LDAP server: %s" % e

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -83,17 +83,20 @@ def login(login: str, password: str) -> tuple:
         c.search(search_base = SEARCH_BASE,
                  search_filter = search_filter,
                  search_scope = SUBTREE,
-                 attributes = [EMAIL_ATTRIBUTE,FULL_NAME_ATTRIBUTE],
+                 attributes = [SEARCH_ATTRIBUTE, EMAIL_ATTRIBUTE, FULL_NAME_ATTRIBUTE],
                  paged_size = 5)
 
         if len(c.response) > 0:
             dn = c.response[0].get('dn')
+            searched_attr = c.response[0].get('raw_attributes').get(SEARCH_ATTRIBUTE)[0].decode('utf-8')
             user_email = c.response[0].get('raw_attributes').get(EMAIL_ATTRIBUTE)[0].decode('utf-8')
             full_name = c.response[0].get('raw_attributes').get(FULL_NAME_ATTRIBUTE)[0].decode('utf-8')
 
-            user_conn = Connection(server, auto_bind = True, client_strategy = SYNC, user = dn, password = password, authentication = SIMPLE, check_names = True)
+            user_conn = Connection(server, auto_bind = True, client_strategy = SYNC,
+                                   check_names = True, authentication = SIMPLE,
+                                   user = dn, password = password)
 
-            return (user_email, full_name)
+            return (searched_attr, user_email, full_name)
 
         raise LDAPLoginError({"error_message": "Login or password incorrect"})
 

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -57,13 +57,13 @@ def login(username: str, password: str) -> tuple:
         server = Server(SERVER, port = PORT, get_info = NONE, use_ssl = use_ssl)
 
         if BIND_DN is not None and BIND_DN != '':
-            user=BIND_DN
-            password=BIND_PASSWORD
-            authentication=SIMPLE
+            user = BIND_DN
+            password = BIND_PASSWORD
+            authentication = SIMPLE
         else:
-            user=None
-            password=None
-            authentication=ANONYMOUS
+            user = None
+            password = None
+            authentication = ANONYMOUS
         c = Connection(server, auto_bind = True, client_strategy = SYNC, check_names = True,
                        user = user, password = password, authentication = authentication)
 

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -38,7 +38,7 @@ BIND_PASSWORD = getattr(settings, "LDAP_BIND_PASSWORD", "")
 EMAIL_PROPERTY = getattr(settings, "LDAP_EMAIL_PROPERTY", "")
 FULL_NAME_PROPERTY = getattr(settings, "LDAP_FULL_NAME_PROPERTY", "")
 
-def login(username: str, password: str) -> tuple:
+def login(login: str, password: str) -> tuple:
     """
     Connect to LDAP server, perform a search and attempt a bind.
 
@@ -73,9 +73,9 @@ def login(username: str, password: str) -> tuple:
 
     try:
         if(SEARCH_SUFFIX is not None and SEARCH_SUFFIX != ''):
-            search_filter = '(%s=%s)' % (SEARCH_PROPERTY, username + SEARCH_SUFFIX)
+            search_filter = '(%s=%s)' % (SEARCH_PROPERTY, login + SEARCH_SUFFIX)
         else:
-            search_filter = '(%s=%s)' % (SEARCH_PROPERTY, username)
+            search_filter = '(%s=%s)' % (SEARCH_PROPERTY, login)
         if SEARCH_FILTER:
             search_filter = '(&%s(%s))' % (search_filter, SEARCH_FILTER)
         c.search(search_base = SEARCH_BASE,
@@ -93,7 +93,7 @@ def login(username: str, password: str) -> tuple:
 
             return (user_email, full_name)
 
-        raise LDAPLoginError({"error_message": "Username or password incorrect"})
+        raise LDAPLoginError({"error_message": "Login or password incorrect"})
 
     except Exception as e:
         error = "LDAP account or password incorrect: %s" % e

--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -29,14 +29,14 @@ SERVER = getattr(settings, "LDAP_SERVER", "")
 PORT = getattr(settings, "LDAP_PORT", "")
 
 SEARCH_BASE = getattr(settings, "LDAP_SEARCH_BASE", "")
-SEARCH_PROPERTY = getattr(settings, "LDAP_SEARCH_PROPERTY", "")
-SEARCH_SUFFIX = getattr(settings, "LDAP_SEARCH_SUFFIX", "")
+SEARCH_ATTRIBUTE = getattr(settings, "LDAP_SEARCH_ATTRIBUTE", "")
+SEARCH_ATTRIBUTE_SUFFIX = getattr(settings, "LDAP_SEARCH_ATTRIBUTE_SUFFIX", "")
 SEARCH_FILTER = getattr(settings, "LDAP_SEARCH_FILTER", "")
 BIND_DN = getattr(settings, "LDAP_BIND_DN", "")
 BIND_PASSWORD = getattr(settings, "LDAP_BIND_PASSWORD", "")
 
-EMAIL_PROPERTY = getattr(settings, "LDAP_EMAIL_PROPERTY", "")
-FULL_NAME_PROPERTY = getattr(settings, "LDAP_FULL_NAME_PROPERTY", "")
+EMAIL_ATTRIBUTE = getattr(settings, "LDAP_EMAIL_ATTRIBUTE", "")
+FULL_NAME_ATTRIBUTE = getattr(settings, "LDAP_FULL_NAME_ATTRIBUTE", "")
 
 def login(login: str, password: str) -> tuple:
     """
@@ -72,22 +72,24 @@ def login(login: str, password: str) -> tuple:
         raise LDAPLoginError({"error_message": error})
 
     try:
-        if(SEARCH_SUFFIX is not None and SEARCH_SUFFIX != ''):
-            search_filter = '(%s=%s)' % (SEARCH_PROPERTY, login + SEARCH_SUFFIX)
+        if(SEARCH_ATTRIBUTE_SUFFIX is not None and SEARCH_ATTRIBUTE_SUFFIX != ''):
+            search_filter = '(%s=%s)' % (SEARCH_ATTRIBUTE, login + SEARCH_ATTRIBUTE_SUFFIX)
         else:
-            search_filter = '(%s=%s)' % (SEARCH_PROPERTY, login)
+            search_filter = '(%s=%s)' % (SEARCH_ATTRIBUTE, login)
+
         if SEARCH_FILTER:
             search_filter = '(&%s(%s))' % (search_filter, SEARCH_FILTER)
+
         c.search(search_base = SEARCH_BASE,
                  search_filter = search_filter,
                  search_scope = SUBTREE,
-                 attributes = [EMAIL_PROPERTY,FULL_NAME_PROPERTY],
+                 attributes = [EMAIL_ATTRIBUTE,FULL_NAME_ATTRIBUTE],
                  paged_size = 5)
 
         if len(c.response) > 0:
             dn = c.response[0].get('dn')
-            user_email = c.response[0].get('raw_attributes').get(EMAIL_PROPERTY)[0].decode('utf-8')
-            full_name = c.response[0].get('raw_attributes').get(FULL_NAME_PROPERTY)[0].decode('utf-8')
+            user_email = c.response[0].get('raw_attributes').get(EMAIL_ATTRIBUTE)[0].decode('utf-8')
+            full_name = c.response[0].get('raw_attributes').get(FULL_NAME_ATTRIBUTE)[0].decode('utf-8')
 
             user_conn = Connection(server, auto_bind = True, client_strategy = SYNC, user = dn, password = password, authentication = SIMPLE, check_names = True)
 

--- a/taiga_contrib_ldap_auth/services.py
+++ b/taiga_contrib_ldap_auth/services.py
@@ -29,7 +29,7 @@ def ldap_register(username: str, email: str, full_name: str):
     """
     Register a new user from LDAP.
 
-    This can raise `exc.IntegrityError` exceptions in
+    Can raise `exc.IntegrityError` exceptions in
     case of conflict found.
 
     :returns: User
@@ -37,13 +37,13 @@ def ldap_register(username: str, email: str, full_name: str):
     user_model = apps.get_model("users", "User")
 
     try:
-        # LDAP user association exist?
+        # LDAP user association exists?
         user = user_model.objects.get(username = username)
     except user_model.DoesNotExist:
         # Create a new user
         username_unique = slugify_uniquely(username, user_model, slugfield = "username")
-        user = user_model.objects.create(email = email,
-                                         username = username_unique,
+        user = user_model.objects.create(username = username_unique,
+                                         email = email,
                                          full_name = full_name)
         user_registered_signal.send(sender = user.__class__, user = user)
 
@@ -59,7 +59,6 @@ def ldap_login_func(request):
     # TODO: make sure these fields are sanitized before passing to LDAP server!
     username, email, full_name = connector.login(login = login_input, password = password_input)
 
-    # TODO: ldap_register() does too much
     user = ldap_register(username = username, email = email, full_name = full_name)
 
     data = make_auth_response_data(user)

--- a/taiga_contrib_ldap_auth/services.py
+++ b/taiga_contrib_ldap_auth/services.py
@@ -38,14 +38,14 @@ def ldap_register(username: str, email: str, full_name: str):
 
     try:
         # LDAP user association exist?
-        user = user_model.objects.get(username=username)
+        user = user_model.objects.get(username = username)
     except user_model.DoesNotExist:
         # Create a new user
-        username_unique = slugify_uniquely(username, user_model, slugfield="username")
-        user = user_model.objects.create(email=email,
-                                         username=username_unique,
-                                         full_name=full_name)
-        user_registered_signal.send(sender=user.__class__, user=user)
+        username_unique = slugify_uniquely(username, user_model, slugfield = "username")
+        user = user_model.objects.create(email = email,
+                                         username = username_unique,
+                                         full_name = full_name)
+        user_registered_signal.send(sender = user.__class__, user = user)
 
     return user
 
@@ -54,7 +54,7 @@ def ldap_login_func(request):
     username = request.DATA.get('username', None)
     password = request.DATA.get('password', None)
 
-    email, full_name = connector.login(username=username, password=password)
-    user = ldap_register(username=username, email=email, full_name=full_name)
+    email, full_name = connector.login(username = username, password = password)
+    user = ldap_register(username = username, email = email, full_name = full_name)
     data = make_auth_response_data(user)
     return data

--- a/taiga_contrib_ldap_auth/services.py
+++ b/taiga_contrib_ldap_auth/services.py
@@ -51,10 +51,16 @@ def ldap_register(username: str, email: str, full_name: str):
 
 
 def ldap_login_func(request):
-    username = request.DATA.get('username', None)
-    password = request.DATA.get('password', None)
+    # although the form field is called 'username', it can be an e-mail
+    # (or any other attribute)
+    login_input = request.DATA.get('username', None)
+    password_input = request.DATA.get('password', None)
 
-    email, full_name = connector.login(username = username, password = password)
+    # TODO: make sure these fields are sanitized before passing to LDAP server!
+    username, email, full_name = connector.login(login = login_input, password = password_input)
+
+    # TODO: ldap_register() does too much
     user = ldap_register(username = username, email = email, full_name = full_name)
+
     data = make_auth_response_data(user)
     return data

--- a/tests/test_ldap.py
+++ b/tests/test_ldap.py
@@ -31,18 +31,19 @@ def test_ldap_login_success():
         m_server.return_value = Mock()
         m_connection.return_value = Mock()
 
-        username = "**userName**"
+        login = "**userName**"
         password = "**password**"
-        (email, full_name) = connector.login(username, password)
-        assert email == username + BASE_EMAIL
-        assert full_name == username
+        (username, email, full_name) = connector.login(login, password)
+        assert username == login
+        assert email == login + BASE_EMAIL
+        assert full_name == login
 
 
 def test_ldap_login_fail():
     with pytest.raises(connector.LDAPLoginError) as e:
-        username = "**userName**"
+        login = "**userName**"
         password = "**password**"
-        auth_info = connector.login(username, password)
+        auth_info = connector.login(login, password)
 
     assert e.value.status_code == 400
     assert "error_message" in e.value.detail


### PR DESCRIPTION
Most important changes:

* rename `PROPERTY` to `ATTRIBUTE` in settings - that's the [proper term](https://www.ldap.com/glossary-of-ldap-terms);
* remove `LDAP_SEARCH_SUFFIX` - guess this was a workaround for searching e-mails;
* remove `LDAP_SEARCH_PROPERTY` and add `LDAP_USERNAME_ATTRIBUTE`;
* perform LDAP search operations by _both_ `LDAP_{USERNAME,EMAIL}_ATTRIBUTE` by default - login form says "Username or email";
* rename `LDAP_SEARCH_FILTER` to `LDAP_SEARCH_FILTER_ADDITIONAL`, don't add parentheses around it in code - making the configuration look more filter-like, e.g. `(|(&(a=*)(b=*))(c=x))`;
* avoid code repetition by setting variables and using those instead (as visible in e.g. `Server`/`Connection` object creation);
* don't collate several `Server`/`Connection` calls in a single `try` - this will simplifiy debug logging (not included in this PR) and non-wrapping exception handling (if needed in the future);
* some whitespace changes - purely cosmetic in function parameters, for consistent style;
* bump version to `0.2.0`;
* reformat README.

Let me know if something needs clarification.

Fixes #37.

Independent of #46 (no merge conflict). ~~Conflicts with #48 (see there).~~