### PR TITLE
services: slugify before DB lookup

### DIFF
--- a/taiga_contrib_ldap_auth/services.py
+++ b/taiga_contrib_ldap_auth/services.py
@@ -35,13 +35,13 @@ def ldap_register(username: str, email: str, full_name: str):
     :returns: User
     """
     user_model = apps.get_model("users", "User")
+    username_unique = slugify_uniquely(username, user_model, slugfield="username")
 
     try:
         # LDAP user association exist?
-        user = user_model.objects.get(username=username)
+        user = user_model.objects.get(username=username_unique)
     except user_model.DoesNotExist:
         # Create a new user
-        username_unique = slugify_uniquely(username, user_model, slugfield="username")
         user = user_model.objects.create(email=email,
                                          username=username_unique,
                                          full_name=full_name)


### PR DESCRIPTION
In `ldap_register()`, LDAP binding has already been performed, and the user is allowed to authenticate. However, the current logic is to look up the user entry in local DB using the string from the login form. If the latter fails, creating a new user is attempted - which might have been already created!

This still does not allow special characters (as in #43, which can be unsafe), but does address the underlying issue.

Should fix #15, #17, #45, and make #43 obsolete.

This PR **conflicts** with #47 due to whitespace changes in the latter. If either gets merged first, I can rebase the other one.